### PR TITLE
chore: simplify main branch protection guidance

### DIFF
--- a/docs/github-repo-settings.md
+++ b/docs/github-repo-settings.md
@@ -7,8 +7,7 @@ These settings turn the process docs into real guardrails.
 Enable:
 
 - require pull request before merging
-- require at least 1 approval
-- dismiss stale approvals when new commits are pushed
+- do not require an approval while the repo is primarily single-maintainer
 - require conversation resolution before merging
 - require status checks before merging
 - require branches to be up to date before merging
@@ -18,14 +17,26 @@ Do not allow force pushes to `main`.
 
 ## Suggested status checks
 
-As CI is added, require checks such as:
+Require only stable checks that represent actual workflow discipline. For now, keep:
+
+- Branch name policy
+- PR body policy
+
+As CI is added later, consider checks such as:
 
 - lint
 - test
 - build
 - typecheck
 
-Do not require checks that are flaky or not consistently maintained.
+Do not require checks that are flaky, protected behind external auth, or not consistently maintained.
+
+## Vercel previews
+
+Vercel preview deploys are useful feedback, but they are not a merge gate for the repo right now.
+
+- treat preview success as a helpful signal
+- do not block merges on preview failures unless the deployment setup becomes reliable and intentionally required
 
 ## Merge strategy
 
@@ -66,9 +77,10 @@ Create and maintain only a small core label set:
 ## Review expectations
 
 - PR author links the issue.
-- Reviewer checks against the issue acceptance criteria and plan.
-- Reviewer calls out missing validation explicitly.
-- PR should not be approved if the linked issue lacks a plan.
+- Review is encouraged, but not required while the repo is primarily single-maintainer.
+- If a review does happen, the reviewer should check against the issue acceptance criteria and plan.
+- Reviewers should call out missing validation explicitly.
+- If the team grows, reintroduce required approval rather than relying on custom norms.
 
 ## Operational rule
 


### PR DESCRIPTION
## Summary

- Problem: The repository required an approving review even though the current workflow is effectively single-maintainer.
- Scope: Remove the required approval gate from `main`, keep PRs and the two governance checks required, and update the written repo policy to match.
- Approach: Update live branch protection first, then align `docs/github-repo-settings.md` with the lighter protection and Vercel preview policy.

## Issue Link

- Closes #8

## Plan Check

- [x] The linked issue contains a written plan
- [x] Scope stayed within the issue boundary
- [x] Follow-up work was split into separate issues instead of expanding this PR

## Validation

- [x] Automated validation run
- [x] Manual validation run
- [ ] Validation gap called out below

## UI Review

- [x] No UI changes in this PR
- [x] Existing design patterns reused
- [ ] New visual pattern justified below

### Validation Details

- Tests: `gh api repos/rschroed/SceneTogether/branches/main/protection`; `gh pr view 5 --repo rschroed/SceneTogether --json reviewDecision,mergeStateStatus,isDraft,url,statusCheckRollup`
- Manual checks: Confirmed `required_approving_review_count` is now `0`, the required checks remain `Branch name policy` and `PR body policy`, and PR #5 is no longer blocked by missing approval.
- Remaining risk: PR #5 still shows `UNSTABLE` because Vercel is failing, but that check is not required under the current protection model.

### UI Notes

- Primary decision this screen supports: None.
- Dominant focal point: None.
- New pattern justification: None.

## Reviewer Notes

- Areas that need close attention: Whether the repo-settings wording now accurately reflects the intended long-term fallback path if the team grows.
- Intentional non-goals: Workflow-file changes, app changes, or deployment protection changes.
