### PR TITLE
Link foundations sheet from design docs

### DIFF
--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -165,6 +165,9 @@ The reference set suggests a narrow, high-energy palette family:
 
 The palette should stay constrained. Too many accent colors will collapse the visual discipline.
 
+For the current visual companion artifact, see the SceneTogether foundations sheet in Paper:
+https://app.paper.design/file/01KNG6S0KT4QKNXSDFB2HFQQ5A
+
 ## Typography direction
 
 Typography should do a large share of the branding work.
@@ -180,6 +183,8 @@ Avoid:
 - default system-only branding
 - soft, neutral startup typography
 - mixing too many expressive type voices
+
+The Paper foundations sheet above should be used as the visual reference for the current color and type pairing, while this document remains the written source for design intent.
 
 ## Design review questions
 

--- a/docs/ui-system.md
+++ b/docs/ui-system.md
@@ -6,6 +6,11 @@ This document turns the design principles into implementation constraints.
 
 All production UI should resolve through shared tokens once the frontend exists.
 
+The current color and typography foundations sheet lives in Paper as a visual companion to this document:
+https://app.paper.design/file/01KNG6S0KT4QKNXSDFB2HFQQ5A
+
+This repo remains the normative written source; the Paper page is the companion artifact for visual alignment.
+
 Token categories to define early:
 
 - color
@@ -95,6 +100,8 @@ Do not:
 - use the display face for dense paragraphs
 - mix multiple expressive display faces
 - fall back to bland default stacks for branded surfaces unless temporarily blocked
+
+Use the Paper foundations sheet above as the current reference for the approved color palette, font pairing, and text-role examples when translating these rules into tokens and primitives.
 
 ## Layout system
 


### PR DESCRIPTION
## Problem

The repo docs described SceneTogether visual direction in prose, but they did not point contributors to the Paper foundations sheet for the approved color and typography reference. That made it easier for UI work to drift away from the intended visual direction.

## Plan

- Link the Paper foundations sheet from the design principles doc where color and typography direction are described.
- Link the same sheet from the UI system doc near the token and type guidance.
- Keep the repo docs as the normative written source and frame the Paper page as the visual companion.

## Changes made

- Added the SceneTogether foundations sheet link to docs/design-principles.md.
- Added the same link to docs/ui-system.md.
- Clarified in both places that the repo remains the written source of truth and the Paper page is the companion artifact for visual alignment.

## Validation performed

- Reviewed the markdown diff for both docs.
- Confirmed the Paper URL appears in both docs.
- Confirmed the wording keeps the repo docs primary rather than delegating source-of-truth ownership to Paper.
- Residual risk: this does not enforce future doc updates automatically; it only improves discoverability for contributors.

## Follow-up work

- None for this slice.

## Issue Link

Closes #17

## Plan Check

- [x] The linked issue contains a written plan
- [x] Scope stayed within the issue boundary
- [x] Follow-up work was split into separate issues instead of expanding this PR
